### PR TITLE
Fix quality-review findings: CI gates, permission hardening, act race, doc truth sweep

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,26 @@ All notable changes to vibesurfer are recorded here. The format follows
 
 ## [Unreleased]
 
+### Security
+- File-permission hardening on Unix. The fallback AES-256 master key (`~/.vibesurfer/key`) is now created with mode 0600 (and tightened to 0600 when overwriting a pre-existing looser file); the daemon data directory (`~/.vibesurfer`) is created with / tightened to 0700; the daemon socket is chmod'd to 0600 after bind. Previously all three inherited the process umask, which typically left the key, the SQLite store (cookies + auth blobs), and the socket world-readable.
+- Added `SECURITY.md` with a private vulnerability-disclosure path.
+
+### Fixed
+- Closed the check-then-act race in `vs_act`: a per-page mutation lock now covers the stale-token check → engine act → re-snapshot window, so two concurrent acts carrying the same `before_token` can no longer both pass the check. Regression test included.
+- `vs serve --stop` on Windows no longer silently coerces an out-of-range PID to 0 before `OpenProcess`; it errors instead.
+- A snapshot node whose ref exceeds `u32` is now dropped instead of silently aliasing `Ref(0)`.
+- Engine completion paths (`open`/`capture`/`eval` on WebKitGTK and WKWebView) return an engine error instead of `unreachable!()` if the run loop ever reports completion without a result — an invariant break there no longer panics the daemon.
+- `cargo fmt` / `clippy 1.94` violations that had crept into `vs-cli` and the v0.1.12 libei path.
+
+### Changed
+- Docs trued up against the code:
+  - `docs/known-issues.md` no longer claims `NetIdle`/`TokenChange` waits and the Windows backend are unimplemented (all shipped; the M6 suite runs on real WebView2 in CI), and reflects host-side cookie capture (HttpOnly included).
+  - The README's trusted-input section reflects the v0.1.11 state instead of announcing it as future work; the primitive count is corrected to 29 wire primitives; the stale README copies bundled with `vs-cli` / `vs-daemon` are re-synced.
+  - `docs/PRIMITIVES.md` is scoped to the 19 core primitives it actually specifies, points at SKILL.md/CHANGELOG for the v0.1.8+ additions, and no longer claims `vs_auth save` captures IndexedDB (it doesn't).
+  - `docs/ROADMAP.md` and `docs/M6_PLAN.md` are marked historical (M0–M6 shipped); the roadmap's "Beyond M6" list reflects that Windows and the MCP shim shipped.
+  - `docs/DEVELOPMENT.md` no longer describes Windows as pending manual verification.
+  - `dist/vibesurfer.rb` points at v0.1.13 with a real tarball SHA instead of v0.0.1 with a placeholder.
+
 
 
 ## [v0.1.13] - 2026-06-02

--- a/README.md
+++ b/README.md
@@ -111,7 +111,7 @@ Modern anti-bot systems (Cloudflare, hCaptcha, reCAPTCHA, DataDome) gate first o
 
 On macOS, `vs act click` and the coordinate primitives (`vs click-at`, `vs hover-at`, `vs move-to`, `vs drag`) route through native `NSEvent` mouseDown / mouseUp / mouseMoved on `WKWebView`. Each event carries `isTrusted = true` in JS, same as a real cursor click. The Bezier-pathed lead-in dispatched before every click reproduces Fitts-law arrival timing (digraph-derived control points, optional overshoot) so the visible motion looks like a human reaching the target rather than a teleport.
 
-Linux (WebKitGTK) and Windows (WebView2) currently still dispatch clicks through injected JS, so `isTrusted` is `false` on those engines. The next release (v0.1.9) wires native input on both: GDK `gdk_display_put_event` for WebKitGTK, CDP `Input.dispatchMouseEvent` for WebView2.
+Since v0.1.11 the coordinate primitives are native on Linux and Windows too: XTest over `x11rb` on WebKitGTK (X11 / Xwayland; pure Wayland falls back to `ENGINE_UNSUPPORTED`), `SendMouseInput` on a WebView2 composition controller on Windows. All three engines emit `isTrusted = true` for cursor-primitive clicks. Ref-based `vs act click` is trusted on macOS only — on Linux and Windows it still dispatches through injected JS (`isTrusted = false`); use the coordinate primitives there for fingerprint-sensitive sites.
 
 The walker also honors ARIA `role="..."` (Radix UI, Headless UI, Reach UI, every custom-div-as-button pattern), plus a tabindex heuristic for focusable divs/spans without a role. Modern React UIs surface as actionable refs without coordinate workarounds.
 
@@ -179,7 +179,7 @@ Every primitive call writes one row to a SQLite audit log before it returns. `vs
 
 The daemon auto-spawns on first call. State, captures, and downloads live under `~/.vibesurfer/`. The transport is an AF_UNIX socket on Unix (`~/.vibesurfer/daemon.sock`) and a Windows named pipe on Windows; either way, the CLI handles the difference.
 
-20 primitives total, each documented in [docs/PRIMITIVES.md](docs/PRIMITIVES.md). The full wire format with every sigil and edge case is in [docs/PROTOCOL.md](docs/PROTOCOL.md). The per-platform per-primitive verification matrix is in [docs/REALITY_CHECK.md](docs/REALITY_CHECK.md).
+29 wire primitives total — the 19 core primitives are specified in [docs/PRIMITIVES.md](docs/PRIMITIVES.md); the later additions (`vs_inspect`, the four cursor primitives, prompt-input, and the pending queue) are documented in the bundled [SKILL.md](crates/vs-cli/SKILL.md) and the CHANGELOG. The full wire format with every sigil and edge case is in [docs/PROTOCOL.md](docs/PROTOCOL.md). The per-platform per-primitive verification matrix is in [docs/REALITY_CHECK.md](docs/REALITY_CHECK.md).
 
 ## Configuration
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,35 @@
+# Security Policy
+
+## Supported versions
+
+vibesurfer is pre-1.0; only the latest released version receives security
+fixes. Update to the newest release before reporting.
+
+| Version  | Supported |
+| -------- | --------- |
+| latest   | yes       |
+| older    | no        |
+
+## Reporting a vulnerability
+
+Please **do not open a public issue** for security findings.
+
+Report privately via one of:
+
+- GitHub private vulnerability reporting:
+  <https://github.com/frane/vibesurfer/security/advisories/new>
+- Email: <frane.bandov@gmail.com> (subject line starting with
+  `[vibesurfer security]`)
+
+Include a reproduction if you can. You should hear back within a week;
+fixes for confirmed issues are released as soon as practical and credited
+in the CHANGELOG unless you prefer otherwise.
+
+## Scope notes
+
+vibesurfer is a *local* daemon: the threat model assumes the attacker is
+either a web page the agent visits or another local user — not a remote
+network peer (the daemon only listens on a local socket / named pipe).
+Reports about pages escaping the engine sandbox, other local users
+reaching the daemon socket or the on-disk store (`~/.vibesurfer`), or
+secrets leaking into logs/audit rows are all in scope.

--- a/crates/vs-cli/README.md
+++ b/crates/vs-cli/README.md
@@ -111,7 +111,7 @@ Modern anti-bot systems (Cloudflare, hCaptcha, reCAPTCHA, DataDome) gate first o
 
 On macOS, `vs act click` and the coordinate primitives (`vs click-at`, `vs hover-at`, `vs move-to`, `vs drag`) route through native `NSEvent` mouseDown / mouseUp / mouseMoved on `WKWebView`. Each event carries `isTrusted = true` in JS, same as a real cursor click. The Bezier-pathed lead-in dispatched before every click reproduces Fitts-law arrival timing (digraph-derived control points, optional overshoot) so the visible motion looks like a human reaching the target rather than a teleport.
 
-Linux (WebKitGTK) and Windows (WebView2) currently still dispatch clicks through injected JS, so `isTrusted` is `false` on those engines. The next release (v0.1.9) wires native input on both: GDK `gdk_display_put_event` for WebKitGTK, CDP `Input.dispatchMouseEvent` for WebView2.
+Since v0.1.11 the coordinate primitives are native on Linux and Windows too: XTest over `x11rb` on WebKitGTK (X11 / Xwayland; pure Wayland falls back to `ENGINE_UNSUPPORTED`), `SendMouseInput` on a WebView2 composition controller on Windows. All three engines emit `isTrusted = true` for cursor-primitive clicks. Ref-based `vs act click` is trusted on macOS only — on Linux and Windows it still dispatches through injected JS (`isTrusted = false`); use the coordinate primitives there for fingerprint-sensitive sites.
 
 The walker also honors ARIA `role="..."` (Radix UI, Headless UI, Reach UI, every custom-div-as-button pattern), plus a tabindex heuristic for focusable divs/spans without a role. Modern React UIs surface as actionable refs without coordinate workarounds.
 
@@ -179,7 +179,7 @@ Every primitive call writes one row to a SQLite audit log before it returns. `vs
 
 The daemon auto-spawns on first call. State, captures, and downloads live under `~/.vibesurfer/`. The transport is an AF_UNIX socket on Unix (`~/.vibesurfer/daemon.sock`) and a Windows named pipe on Windows; either way, the CLI handles the difference.
 
-20 primitives total, each documented in [docs/PRIMITIVES.md](docs/PRIMITIVES.md). The full wire format with every sigil and edge case is in [docs/PROTOCOL.md](docs/PROTOCOL.md). The per-platform per-primitive verification matrix is in [docs/REALITY_CHECK.md](docs/REALITY_CHECK.md).
+29 wire primitives total — the 19 core primitives are specified in [docs/PRIMITIVES.md](docs/PRIMITIVES.md); the later additions (`vs_inspect`, the four cursor primitives, prompt-input, and the pending queue) are documented in the bundled [SKILL.md](crates/vs-cli/SKILL.md) and the CHANGELOG. The full wire format with every sigil and edge case is in [docs/PROTOCOL.md](docs/PROTOCOL.md). The per-platform per-primitive verification matrix is in [docs/REALITY_CHECK.md](docs/REALITY_CHECK.md).
 
 ## Configuration
 

--- a/crates/vs-cli/src/commands/dispatch.rs
+++ b/crates/vs-cli/src/commands/dispatch.rs
@@ -173,7 +173,9 @@ pub fn run(cli: &Cli) -> Result<Response> {
                 warnings: Vec::new(),
             });
         }
-        Command::Pending { sub: super::PendingSub::Fulfill { id } } => {
+        Command::Pending {
+            sub: super::PendingSub::Fulfill { id },
+        } => {
             return run_pending_fulfill(&mut client, id.clone());
         }
         _ => {}
@@ -193,10 +195,7 @@ pub fn run(cli: &Cli) -> Result<Response> {
                 let _ = mark_caller_closed(&paths, key);
             }
         }
-        (
-            Command::Capture { base64: true, .. },
-            vs_protocol::Envelope::Success(_),
-        ) => {
+        (Command::Capture { base64: true, .. }, vs_protocol::Envelope::Success(_)) => {
             // The body's first line is the on-disk PNG path. Read it
             // and replace the body with `base64=<bytes>` plus the
             // original `path=…` so MCP-driven agents can ship pixels

--- a/crates/vs-cli/src/commands/mod.rs
+++ b/crates/vs-cli/src/commands/mod.rs
@@ -358,9 +358,7 @@ pub enum PendingSub {
     /// Cancel a pending entry. The parked `vs_prompt_input` call
     /// returns `BadRequest "cancelled"`.
     #[command(visible_alias = "c")]
-    Cancel {
-        id: String,
-    },
+    Cancel { id: String },
 }
 
 impl Command {
@@ -528,7 +526,12 @@ impl Command {
                 }
                 req
             }
-            Self::Capture { page, r, full_page, base64: _ } => {
+            Self::Capture {
+                page,
+                r,
+                full_page,
+                base64: _,
+            } => {
                 // `base64` is a CLI-side post-process — the daemon
                 // still returns the on-disk path; dispatch.rs reads
                 // the PNG and base64-encodes it before printing.
@@ -668,7 +671,13 @@ impl Command {
                 anyhow::bail!("vs_prompt_* is local; route via main, not the wire dispatcher");
             }
             Self::PromptInputQueue {
-                page, r, message, secret, token, group, timeout_ms,
+                page,
+                r,
+                message,
+                secret,
+                token,
+                group,
+                timeout_ms,
             } => {
                 let s = require_session(session_id)?;
                 let mut req = Request::new("vs_prompt_input_queue")
@@ -678,8 +687,12 @@ impl Command {
                     .flag_value("session", s)
                     .flag_value("token", token.clone())
                     .flag_value("timeout-ms", timeout_ms.to_string());
-                if *secret { req = req.flag("secret"); }
-                if let Some(g) = group { req = req.flag_value("group", g.clone()); }
+                if *secret {
+                    req = req.flag("secret");
+                }
+                if let Some(g) = group {
+                    req = req.flag_value("group", g.clone());
+                }
                 req
             }
             Self::Pending { sub } => match sub {
@@ -690,7 +703,9 @@ impl Command {
                     // just stub a placeholder; dispatch overrides the
                     // value arg with what the user typed.
                     let id_v = id.clone().unwrap_or_default();
-                    Request::new("vs_pending_fulfill").arg(id_v).arg(String::new())
+                    Request::new("vs_pending_fulfill")
+                        .arg(id_v)
+                        .arg(String::new())
                 }
                 PendingSub::Cancel { id } => Request::new("vs_pending_cancel").arg(id.clone()),
             },
@@ -708,7 +723,11 @@ impl Command {
     pub fn needs_session(&self) -> bool {
         !matches!(
             self,
-            Self::SessionOpen { .. } | Self::Status | Self::Serve { .. } | Self::Mcp | Self::Pending { .. }
+            Self::SessionOpen { .. }
+                | Self::Status
+                | Self::Serve { .. }
+                | Self::Mcp
+                | Self::Pending { .. }
         )
     }
 }

--- a/crates/vs-cli/src/serve.rs
+++ b/crates/vs-cli/src/serve.rs
@@ -66,8 +66,10 @@ pub fn run_stop(paths: &DaemonPaths) -> Result<()> {
     {
         use windows::Win32::Foundation::CloseHandle;
         use windows::Win32::System::Threading::{OpenProcess, TerminateProcess, PROCESS_TERMINATE};
+        let pid_u32 =
+            u32::try_from(pid).with_context(|| format!("PID {pid} out of range for a DWORD"))?;
         unsafe {
-            let h = OpenProcess(PROCESS_TERMINATE, false, u32::try_from(pid).unwrap_or(0))
+            let h = OpenProcess(PROCESS_TERMINATE, false, pid_u32)
                 .map_err(|e| anyhow::anyhow!("OpenProcess({pid}): {e}"))?;
             let r = TerminateProcess(h, 0);
             let _ = CloseHandle(h);

--- a/crates/vs-cli/tests/m6/act.rs
+++ b/crates/vs-cli/tests/m6/act.rs
@@ -35,7 +35,12 @@ fn cell_act_click() {
             &format!("--token={token}"),
         ]);
         assert_ok("click submit", &r_click);
-        let _ = ctx.vs(&["wait", &page, "stable", "--timeout=2000"]);
+        // The click triggers a real navigation to the dashboard.
+        // `stable` (DOM-quiet) can fire on the still-current login
+        // page before the navigation commits — observed as a flake on
+        // macOS CI — so wait for the dashboard's own text instead.
+        let r_wait = ctx.vs(&["wait", &page, "text", "Dashboard", "--timeout=5000"]);
+        assert_ok("wait for dashboard text", &r_wait);
         let title = eval_js(&ctx, &page, "document.title");
         assert!(
             title.contains("Dashboard"),

--- a/crates/vs-daemon/README.md
+++ b/crates/vs-daemon/README.md
@@ -111,7 +111,7 @@ Modern anti-bot systems (Cloudflare, hCaptcha, reCAPTCHA, DataDome) gate first o
 
 On macOS, `vs act click` and the coordinate primitives (`vs click-at`, `vs hover-at`, `vs move-to`, `vs drag`) route through native `NSEvent` mouseDown / mouseUp / mouseMoved on `WKWebView`. Each event carries `isTrusted = true` in JS, same as a real cursor click. The Bezier-pathed lead-in dispatched before every click reproduces Fitts-law arrival timing (digraph-derived control points, optional overshoot) so the visible motion looks like a human reaching the target rather than a teleport.
 
-Linux (WebKitGTK) and Windows (WebView2) currently still dispatch clicks through injected JS, so `isTrusted` is `false` on those engines. The next release (v0.1.9) wires native input on both: GDK `gdk_display_put_event` for WebKitGTK, CDP `Input.dispatchMouseEvent` for WebView2.
+Since v0.1.11 the coordinate primitives are native on Linux and Windows too: XTest over `x11rb` on WebKitGTK (X11 / Xwayland; pure Wayland falls back to `ENGINE_UNSUPPORTED`), `SendMouseInput` on a WebView2 composition controller on Windows. All three engines emit `isTrusted = true` for cursor-primitive clicks. Ref-based `vs act click` is trusted on macOS only — on Linux and Windows it still dispatches through injected JS (`isTrusted = false`); use the coordinate primitives there for fingerprint-sensitive sites.
 
 The walker also honors ARIA `role="..."` (Radix UI, Headless UI, Reach UI, every custom-div-as-button pattern), plus a tabindex heuristic for focusable divs/spans without a role. Modern React UIs surface as actionable refs without coordinate workarounds.
 
@@ -179,7 +179,7 @@ Every primitive call writes one row to a SQLite audit log before it returns. `vs
 
 The daemon auto-spawns on first call. State, captures, and downloads live under `~/.vibesurfer/`. The transport is an AF_UNIX socket on Unix (`~/.vibesurfer/daemon.sock`) and a Windows named pipe on Windows; either way, the CLI handles the difference.
 
-20 primitives total, each documented in [docs/PRIMITIVES.md](docs/PRIMITIVES.md). The full wire format with every sigil and edge case is in [docs/PROTOCOL.md](docs/PROTOCOL.md). The per-platform per-primitive verification matrix is in [docs/REALITY_CHECK.md](docs/REALITY_CHECK.md).
+29 wire primitives total — the 19 core primitives are specified in [docs/PRIMITIVES.md](docs/PRIMITIVES.md); the later additions (`vs_inspect`, the four cursor primitives, prompt-input, and the pending queue) are documented in the bundled [SKILL.md](crates/vs-cli/SKILL.md) and the CHANGELOG. The full wire format with every sigil and edge case is in [docs/PROTOCOL.md](docs/PROTOCOL.md). The per-platform per-primitive verification matrix is in [docs/REALITY_CHECK.md](docs/REALITY_CHECK.md).
 
 ## Configuration
 

--- a/crates/vs-daemon/src/config.rs
+++ b/crates/vs-daemon/src/config.rs
@@ -75,8 +75,17 @@ impl Paths {
         self.root.join("captures")
     }
 
-    /// Ensure the root directory exists.
+    /// Ensure the root directory exists. On Unix the directory is
+    /// created with (or tightened to) mode 0700 — it holds the SQLite
+    /// store, the fallback AES key, and the daemon socket, none of
+    /// which should be visible to other users.
     pub fn ensure_root(&self) -> std::io::Result<()> {
-        std::fs::create_dir_all(&self.root)
+        std::fs::create_dir_all(&self.root)?;
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt as _;
+            std::fs::set_permissions(&self.root, std::fs::Permissions::from_mode(0o700))?;
+        }
+        Ok(())
     }
 }

--- a/crates/vs-daemon/src/daemon/mod.rs
+++ b/crates/vs-daemon/src/daemon/mod.rs
@@ -17,8 +17,8 @@ pub mod responses;
 mod engine_ops;
 mod lifecycle;
 mod page_ops;
-mod store_ops;
 pub mod pending;
+mod store_ops;
 
 use std::collections::HashMap;
 use std::sync::{Arc, Mutex};
@@ -209,6 +209,23 @@ impl Daemon {
             .get(page_id)
             .ok_or_else(|| DaemonError::UnknownPage(page_id.to_string()))?;
         Ok(page.engine_handle)
+    }
+
+    /// Clone the per-page mutation lock so callers can hold it across
+    /// an engine call without keeping the session map locked.
+    pub(crate) fn mutate_lock_for(
+        &self,
+        session_id: &str,
+        page_id: &str,
+    ) -> Result<Arc<Mutex<()>>> {
+        let sessions = self.inner.sessions.lock().expect("poisoned");
+        let page = sessions
+            .get(session_id)
+            .ok_or_else(|| DaemonError::UnknownSession(session_id.to_string()))?
+            .pages
+            .get(page_id)
+            .ok_or_else(|| DaemonError::UnknownPage(page_id.to_string()))?;
+        Ok(page.mutate_lock.clone())
     }
 
     pub(crate) fn current_token(&self, session_id: &str, page_id: &str) -> Result<StateToken> {

--- a/crates/vs-daemon/src/daemon/page_ops.rs
+++ b/crates/vs-daemon/src/daemon/page_ops.rs
@@ -93,6 +93,12 @@ impl Daemon {
             .with_before(before_token)
             .with_group(group_label);
         self.audit_call(ctx, |ctx| {
+            // Hold the page's mutation lock across the whole
+            // check-then-act window so a concurrent act with the same
+            // before_token can't slip between the stale-token check
+            // and the engine call.
+            let mutate_lock = self.mutate_lock_for(&session_id, &page_id)?;
+            let _mutate_guard = mutate_lock.lock().expect("poisoned");
             let engine_handle = self.engine_handle_for(&session_id, &page_id)?;
             let current_token = self.current_token(&session_id, &page_id)?;
             if current_token != before_token {

--- a/crates/vs-daemon/src/page_state.rs
+++ b/crates/vs-daemon/src/page_state.rs
@@ -5,6 +5,7 @@
 //! used by [`view`](crate::handlers) to compute deltas.
 
 use std::collections::HashSet;
+use std::sync::{Arc, Mutex};
 
 use vs_engine_webkit::PageHandle;
 use vs_protocol::{DeltaOp, Ref, StateToken, Tree};
@@ -28,6 +29,12 @@ pub struct PageState {
     pub force_full: bool,
     /// Refs ever seen on this page, for retire-tracking.
     pub seen_refs: HashSet<Ref>,
+    /// Serializes `vs_act`'s token-check → engine-act → re-snapshot
+    /// window. Without it, two concurrent acts carrying the same
+    /// `before_token` would both pass the stale-token check before
+    /// either mutation lands. Kept outside the session-map mutex so
+    /// the (slow) engine call doesn't block unrelated pages.
+    pub mutate_lock: Arc<Mutex<()>>,
 }
 
 impl PageState {
@@ -41,6 +48,7 @@ impl PageState {
             last_token: None,
             force_full: true,
             seen_refs: HashSet::new(),
+            mutate_lock: Arc::new(Mutex::new(())),
         }
     }
 

--- a/crates/vs-daemon/src/server/engine_ops.rs
+++ b/crates/vs-daemon/src/server/engine_ops.rs
@@ -873,7 +873,10 @@ pub(super) fn handle_prompt_input_queue(daemon: &Daemon, req: &Request) -> Strin
         );
     };
     let Ok(r) = r_str.parse::<Ref>() else {
-        return format_error(ErrorCode::BadRequest, vec!["vs_prompt_input_queue: bad ref".into()]);
+        return format_error(
+            ErrorCode::BadRequest,
+            vec!["vs_prompt_input_queue: bad ref".into()],
+        );
     };
     let Some(message) = req.args.get(2).cloned() else {
         return format_error(
@@ -882,7 +885,10 @@ pub(super) fn handle_prompt_input_queue(daemon: &Daemon, req: &Request) -> Strin
         );
     };
     let Some(token) = flag_value(req, "token") else {
-        return format_error(ErrorCode::BadRequest, vec!["vs_prompt_input_queue: missing --token".into()]);
+        return format_error(
+            ErrorCode::BadRequest,
+            vec!["vs_prompt_input_queue: missing --token".into()],
+        );
     };
     let secret = req.flags.contains_key("secret");
     let group = flag_value(req, "group");
@@ -891,7 +897,16 @@ pub(super) fn handle_prompt_input_queue(daemon: &Daemon, req: &Request) -> Strin
         Some(ms) => std::time::Duration::from_millis(ms),
         None => std::time::Duration::from_secs(300),
     };
-    match daemon.prompt_input_queue(&session_id, &page_id, r, message, secret, token, group, timeout) {
+    match daemon.prompt_input_queue(
+        &session_id,
+        &page_id,
+        r,
+        message,
+        secret,
+        token,
+        group,
+        timeout,
+    ) {
         Ok(after) => ResponseHead::ok(after).encode(),
         Err(e) => format_daemon_error(&e),
     }
@@ -906,10 +921,18 @@ pub(super) fn handle_pending_list(daemon: &Daemon, _req: &Request) -> String {
         let _ = writeln!(
             body,
             "{}\t{}\t{}\t{}\t{}",
-            e.id, e.page, e.r, u8::from(e.secret), e.message
+            e.id,
+            e.page,
+            e.r,
+            u8::from(e.secret),
+            e.message
         );
     }
-    format!("{}{}", ResponseHead::ok(StateToken([0u8; 8])).encode(), body)
+    format!(
+        "{}{}",
+        ResponseHead::ok(StateToken([0u8; 8])).encode(),
+        body
+    )
 }
 
 pub(super) fn handle_pending_fulfill(daemon: &Daemon, req: &Request) -> String {
@@ -928,7 +951,10 @@ pub(super) fn handle_pending_fulfill(daemon: &Daemon, req: &Request) -> String {
     if daemon.pending_fulfill(&id, value) {
         ResponseHead::ok(StateToken([0u8; 8])).encode()
     } else {
-        format_error(ErrorCode::NotFound, vec![format!("pending entry {id} not found")])
+        format_error(
+            ErrorCode::NotFound,
+            vec![format!("pending entry {id} not found")],
+        )
     }
 }
 
@@ -942,7 +968,10 @@ pub(super) fn handle_pending_cancel(daemon: &Daemon, req: &Request) -> String {
     if daemon.pending_cancel(&id) {
         ResponseHead::ok(StateToken([0u8; 8])).encode()
     } else {
-        format_error(ErrorCode::NotFound, vec![format!("pending entry {id} not found")])
+        format_error(
+            ErrorCode::NotFound,
+            vec![format!("pending entry {id} not found")],
+        )
     }
 }
 
@@ -957,8 +986,15 @@ pub(super) fn handle_pending_peek(daemon: &Daemon, req: &Request) -> String {
         Some(e) => format!(
             "{}{}\t{}\t{}\t{}\t{}\n",
             ResponseHead::ok(StateToken([0u8; 8])).encode(),
-            e.id, e.page, e.r, u8::from(e.secret), e.message
+            e.id,
+            e.page,
+            e.r,
+            u8::from(e.secret),
+            e.message
         ),
-        None => format_error(ErrorCode::NotFound, vec![format!("pending entry {id} not found")]),
+        None => format_error(
+            ErrorCode::NotFound,
+            vec![format!("pending entry {id} not found")],
+        ),
     }
 }

--- a/crates/vs-daemon/src/server/mod.rs
+++ b/crates/vs-daemon/src/server/mod.rs
@@ -60,6 +60,17 @@ pub async fn serve(
             );
             e
         })?;
+    // Only the owning user may talk to the daemon: the socket carries
+    // cookie/auth state and drives a real browser. The parent dir is
+    // 0700 (see `Paths::ensure_root`), but the socket itself may live
+    // under a custom path, so tighten it explicitly too.
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt as _;
+        if let Err(e) = std::fs::set_permissions(path, std::fs::Permissions::from_mode(0o600)) {
+            tracing::warn!(?path, error = %e, "could not restrict socket permissions");
+        }
+    }
     tracing::info!(?path, "vibesurfer daemon listening");
 
     let daemon = Arc::new(daemon);

--- a/crates/vs-daemon/tests/end_to_end.rs
+++ b/crates/vs-daemon/tests/end_to_end.rs
@@ -835,3 +835,44 @@ fn view_no_warning_when_no_new_errors() {
     let w2 = &d.dispatch(&[r()])[0].wire;
     assert!(!w2.contains("? console_error"), "second view: {w2:?}");
 }
+
+/// Regression for the check-then-act race: two concurrent `act` calls
+/// on the same page must serialize on the page's mutation lock and
+/// complete without deadlock. `TestEngine` acts don't change the
+/// snapshot, so both succeed; the assertion here is liveness plus
+/// distinct audit rows (no lost call).
+#[test]
+fn concurrent_acts_on_same_page_serialize_without_deadlock() {
+    let (d, _dir) = make_daemon();
+    let s = d.session_open(None).unwrap();
+    let p = d.open(&s.session_id, "https://x").unwrap();
+    let v = d.view(&s.session_id, &p.page_id, false).unwrap();
+
+    let call = |hash: &str| vs_daemon::daemon::ActCall {
+        session_id: s.session_id.clone(),
+        page_id: p.page_id.clone(),
+        target: engine::ActTarget::Ref(Ref(4)),
+        action: engine::Action::Click,
+        before_token: v.token,
+        args_hash: hash.into(),
+        args_redacted: "click 4".into(),
+        group_label: None,
+    };
+
+    let d2 = d.clone();
+    let c1 = call("hash-a");
+    let t = std::thread::spawn(move || d2.act(c1));
+    let r2 = d.act(call("hash-b"));
+    let r1 = t.join().expect("act thread panicked");
+    r1.expect("first concurrent act failed");
+    r2.expect("second concurrent act failed");
+
+    let actions = d
+        .audit_log(&vs_store::ActionFilter {
+            session_id: Some(s.session_id.clone()),
+            ..Default::default()
+        })
+        .unwrap();
+    let acts = actions.iter().filter(|a| a.primitive == "vs_act").count();
+    assert_eq!(acts, 2, "both concurrent acts must be audited");
+}

--- a/crates/vs-engine-webkit/README.md
+++ b/crates/vs-engine-webkit/README.md
@@ -111,7 +111,7 @@ Modern anti-bot systems (Cloudflare, hCaptcha, reCAPTCHA, DataDome) gate first o
 
 On macOS, `vs act click` and the coordinate primitives (`vs click-at`, `vs hover-at`, `vs move-to`, `vs drag`) route through native `NSEvent` mouseDown / mouseUp / mouseMoved on `WKWebView`. Each event carries `isTrusted = true` in JS, same as a real cursor click. The Bezier-pathed lead-in dispatched before every click reproduces Fitts-law arrival timing (digraph-derived control points, optional overshoot) so the visible motion looks like a human reaching the target rather than a teleport.
 
-Linux (WebKitGTK) and Windows (WebView2) currently still dispatch clicks through injected JS, so `isTrusted` is `false` on those engines. The next release (v0.1.9) wires native input on both: GDK `gdk_display_put_event` for WebKitGTK, CDP `Input.dispatchMouseEvent` for WebView2.
+Since v0.1.11 the coordinate primitives are native on Linux and Windows too: XTest over `x11rb` on WebKitGTK (X11 / Xwayland; pure Wayland falls back to `ENGINE_UNSUPPORTED`), `SendMouseInput` on a WebView2 composition controller on Windows. All three engines emit `isTrusted = true` for cursor-primitive clicks. Ref-based `vs act click` is trusted on macOS only — on Linux and Windows it still dispatches through injected JS (`isTrusted = false`); use the coordinate primitives there for fingerprint-sensitive sites.
 
 The walker also honors ARIA `role="..."` (Radix UI, Headless UI, Reach UI, every custom-div-as-button pattern), plus a tabindex heuristic for focusable divs/spans without a role. Modern React UIs surface as actionable refs without coordinate workarounds.
 
@@ -179,7 +179,7 @@ Every primitive call writes one row to a SQLite audit log before it returns. `vs
 
 The daemon auto-spawns on first call. State, captures, and downloads live under `~/.vibesurfer/`. The transport is an AF_UNIX socket on Unix (`~/.vibesurfer/daemon.sock`) and a Windows named pipe on Windows; either way, the CLI handles the difference.
 
-20 primitives total, each documented in [docs/PRIMITIVES.md](docs/PRIMITIVES.md). The full wire format with every sigil and edge case is in [docs/PROTOCOL.md](docs/PROTOCOL.md). The per-platform per-primitive verification matrix is in [docs/REALITY_CHECK.md](docs/REALITY_CHECK.md).
+29 wire primitives total — the 19 core primitives are specified in [docs/PRIMITIVES.md](docs/PRIMITIVES.md); the later additions (`vs_inspect`, the four cursor primitives, prompt-input, and the pending queue) are documented in the bundled [SKILL.md](crates/vs-cli/SKILL.md) and the CHANGELOG. The full wire format with every sigil and edge case is in [docs/PROTOCOL.md](docs/PROTOCOL.md). The per-platform per-primitive verification matrix is in [docs/REALITY_CHECK.md](docs/REALITY_CHECK.md).
 
 ## Configuration
 

--- a/crates/vs-engine-webkit/src/backend/common.rs
+++ b/crates/vs-engine-webkit/src/backend/common.rs
@@ -78,7 +78,9 @@ pub(crate) fn parse_snapshot(json: &str) -> Result<Tree, String> {
 }
 
 fn build_node(v: &serde_json::Value) -> Option<Node> {
-    let r = v.get("r")?.as_u64()?;
+    // A ref beyond u32 means the page emitted a snapshot we can't
+    // represent — drop the node rather than silently aliasing Ref(0).
+    let r = u32::try_from(v.get("r")?.as_u64()?).ok()?;
     let role_s = v.get("role")?.as_str()?;
     let label = v.get("label").and_then(|x| x.as_str()).unwrap_or("");
     let role = parse_role(role_s);
@@ -91,7 +93,7 @@ fn build_node(v: &serde_json::Value) -> Option<Node> {
         }
     }
     Some(Node {
-        r: Ref(u32::try_from(r).unwrap_or(0)),
+        r: Ref(r),
         role,
         label: label.to_string(),
         ops: ops_for_role(role),
@@ -239,7 +241,6 @@ pub(crate) fn build_html5_drag_js(x1: f64, y1: f64, x2: f64, y2: f64) -> String 
         }})()"
     )
 }
-
 
 pub(crate) fn run_act<F>(eval: F, target: &ActTarget, action: &Action) -> EngineResult<()>
 where

--- a/crates/vs-engine-webkit/src/backend/webkit/eval.rs
+++ b/crates/vs-engine-webkit/src/backend/webkit/eval.rs
@@ -68,6 +68,6 @@ pub(super) fn eval_js_string(
     match result {
         Some(Ok(s)) => Ok(s),
         Some(Err(msg)) => Err(EngineError::Other(format!("eval failed: {msg}"))),
-        None => unreachable!(),
+        None => Err(EngineError::Other("eval completed without a result".into())),
     }
 }

--- a/crates/vs-engine-webkit/src/backend/webkit/mod.rs
+++ b/crates/vs-engine-webkit/src/backend/webkit/mod.rs
@@ -234,7 +234,11 @@ impl Engine for WkBackend {
         match slot.borrow_mut().take() {
             Some(Ok(())) => {}
             Some(Err(msg)) => return Err(EngineError::Other(format!("navigation failed: {msg}"))),
-            None => unreachable!(),
+            None => {
+                return Err(EngineError::Other(
+                    "navigation completed without a result".into(),
+                ))
+            }
         }
 
         let handle = self.alloc_handle();

--- a/crates/vs-engine-webkit/src/backend/webview2.rs
+++ b/crates/vs-engine-webkit/src/backend/webview2.rs
@@ -383,6 +383,11 @@ fn install_inspector(web_view: &ICoreWebView2, slots: &InspectorSlots) -> bool {
 // =============================================================================
 
 impl Engine for Webview2Backend {
+    // The COM bring-up (environment → composition controller →
+    // DirectComposition device/target/visual → settings → navigate)
+    // is one linear sequence; splitting it would just scatter the
+    // handle plumbing.
+    #[allow(clippy::too_many_lines)]
     fn open(&mut self, url: &str) -> EngineResult<PageHandle> {
         let parent = self.create_host_hwnd()?;
 

--- a/crates/vs-engine-webkit/src/backend/webview2.rs
+++ b/crates/vs-engine-webkit/src/backend/webview2.rs
@@ -37,9 +37,8 @@ use webview2_com::Microsoft::Web::WebView2::Win32::{
     ICoreWebView2, ICoreWebView2CompositionController, ICoreWebView2Controller,
     ICoreWebView2Environment, ICoreWebView2Environment3,
     COREWEBVIEW2_CAPTURE_PREVIEW_IMAGE_FORMAT_PNG, COREWEBVIEW2_MOUSE_EVENT_KIND,
-    COREWEBVIEW2_MOUSE_EVENT_KIND_LEFT_BUTTON_DOWN,
-    COREWEBVIEW2_MOUSE_EVENT_KIND_LEFT_BUTTON_UP, COREWEBVIEW2_MOUSE_EVENT_KIND_MOVE,
-    COREWEBVIEW2_MOUSE_EVENT_VIRTUAL_KEYS_NONE,
+    COREWEBVIEW2_MOUSE_EVENT_KIND_LEFT_BUTTON_DOWN, COREWEBVIEW2_MOUSE_EVENT_KIND_LEFT_BUTTON_UP,
+    COREWEBVIEW2_MOUSE_EVENT_KIND_MOVE, COREWEBVIEW2_MOUSE_EVENT_VIRTUAL_KEYS_NONE,
 };
 use webview2_com::{
     pwstr_from_str, take_pwstr, AddScriptToExecuteOnDocumentCreatedCompletedHandler,
@@ -868,18 +867,10 @@ impl Engine for Webview2Backend {
                 let start_pt = vs_humanize::Point { x: x1, y: y1 };
                 let target = vs_humanize::Point { x: x2, y: y2 };
                 let pre = wv2_move_along_path(&comp, start, start_pt, humanize_mode, seed)?;
-                wv2_send_mouse(
-                    &comp,
-                    COREWEBVIEW2_MOUSE_EVENT_KIND_LEFT_BUTTON_DOWN,
-                    pre,
-                )?;
+                wv2_send_mouse(&comp, COREWEBVIEW2_MOUSE_EVENT_KIND_LEFT_BUTTON_DOWN, pre)?;
                 std::thread::sleep(Duration::from_millis(15));
                 let landed = wv2_move_along_path(&comp, pre, target, humanize_mode, seed)?;
-                wv2_send_mouse(
-                    &comp,
-                    COREWEBVIEW2_MOUSE_EVENT_KIND_LEFT_BUTTON_UP,
-                    landed,
-                )?;
+                wv2_send_mouse(&comp, COREWEBVIEW2_MOUSE_EVENT_KIND_LEFT_BUTTON_UP, landed)?;
                 // After the OS-level drag, fire the HTML5 DragEvent
                 // chain in JS so react-dnd / React-Flow HTML5 targets
                 // observe the drop.
@@ -892,7 +883,6 @@ impl Engine for Webview2Backend {
         p.last_mouse.set(landed);
         Ok(())
     }
-
 
     fn capabilities(&self) -> EngineCapabilities {
         let any_inspector = self.pages.values().any(|p| p.inspector_installed);
@@ -951,8 +941,13 @@ fn wv2_send_mouse(
     point: vs_humanize::Point,
 ) -> EngineResult<()> {
     unsafe {
-        comp.SendMouseInput(kind, COREWEBVIEW2_MOUSE_EVENT_VIRTUAL_KEYS_NONE, 0, point_at(point))
-            .map_err(|e| EngineError::Other(format!("SendMouseInput: {e}")))
+        comp.SendMouseInput(
+            kind,
+            COREWEBVIEW2_MOUSE_EVENT_VIRTUAL_KEYS_NONE,
+            0,
+            point_at(point),
+        )
+        .map_err(|e| EngineError::Other(format!("SendMouseInput: {e}")))
     }
 }
 

--- a/crates/vs-engine-webkit/src/backend/wpe.rs
+++ b/crates/vs-engine-webkit/src/backend/wpe.rs
@@ -213,7 +213,11 @@ impl Engine for WpeBackend {
         match slot.borrow_mut().take() {
             Some(Ok(())) => {}
             Some(Err(msg)) => return Err(EngineError::Other(format!("navigation failed: {msg}"))),
-            None => unreachable!(),
+            None => {
+                return Err(EngineError::Other(
+                    "navigation completed without a result".into(),
+                ))
+            }
         }
 
         let handle = self.alloc_handle();
@@ -336,7 +340,9 @@ impl Engine for WpeBackend {
         match result {
             Some(Ok(())) => Ok(path),
             Some(Err(msg)) => Err(EngineError::Other(format!("capture: {msg}"))),
-            None => unreachable!(),
+            None => Err(EngineError::Other(
+                "capture completed without a result".into(),
+            )),
         }
     }
 
@@ -506,27 +512,53 @@ impl Engine for WpeBackend {
         let start = p.last_mouse.get();
         let seed = humanize_seed(op);
         let landed = match op {
-            CursorOp::MoveTo { x, y } | CursorOp::HoverAt { x, y } => {
-                cursor_move_along_path(dispatcher, start, vs_humanize::Point { x, y },
-                    (origin_x, origin_y), humanize_mode, seed, false)?
-            }
+            CursorOp::MoveTo { x, y } | CursorOp::HoverAt { x, y } => cursor_move_along_path(
+                dispatcher,
+                start,
+                vs_humanize::Point { x, y },
+                (origin_x, origin_y),
+                humanize_mode,
+                seed,
+                false,
+            )?,
             CursorOp::ClickAt { x, y } => {
-                let landed = cursor_move_along_path(dispatcher, start, vs_humanize::Point { x, y },
-                    (origin_x, origin_y), humanize_mode, seed, false)?;
+                let landed = cursor_move_along_path(
+                    dispatcher,
+                    start,
+                    vs_humanize::Point { x, y },
+                    (origin_x, origin_y),
+                    humanize_mode,
+                    seed,
+                    false,
+                )?;
                 cursor_press_release(dispatcher, landed, (origin_x, origin_y))?;
                 landed
             }
             CursorOp::Drag { x1, y1, x2, y2 } => {
                 let start_pt = vs_humanize::Point { x: x1, y: y1 };
                 let target = vs_humanize::Point { x: x2, y: y2 };
-                let pre = cursor_move_along_path(dispatcher, start, start_pt,
-                    (origin_x, origin_y), humanize_mode, seed, false)?;
+                let pre = cursor_move_along_path(
+                    dispatcher,
+                    start,
+                    start_pt,
+                    (origin_x, origin_y),
+                    humanize_mode,
+                    seed,
+                    false,
+                )?;
                 dispatcher.dispatch(super::wpe_input::InputEvent::Press(
                     super::wpe_input::Button::Left,
                 ))?;
                 std::thread::sleep(Duration::from_millis(15));
-                let landed = cursor_move_along_path(dispatcher, pre, target,
-                    (origin_x, origin_y), humanize_mode, seed, true)?;
+                let landed = cursor_move_along_path(
+                    dispatcher,
+                    pre,
+                    target,
+                    (origin_x, origin_y),
+                    humanize_mode,
+                    seed,
+                    true,
+                )?;
                 dispatcher.dispatch(super::wpe_input::InputEvent::Release(
                     super::wpe_input::Button::Left,
                 ))?;
@@ -543,7 +575,6 @@ impl Engine for WpeBackend {
         p.last_mouse.set(landed);
         Ok(())
     }
-
 
     fn capabilities(&self) -> EngineCapabilities {
         let any_inspector = self.pages.values().any(|p| p.inspector_installed);
@@ -687,7 +718,7 @@ fn eval_js_string(web_view: &WebView, js: &str, budget: Duration) -> EngineResul
     match result {
         Some(Ok(s)) => Ok(s),
         Some(Err(msg)) => Err(EngineError::Other(format!("eval failed: {msg}"))),
-        None => unreachable!(),
+        None => Err(EngineError::Other("eval completed without a result".into())),
     }
 }
 

--- a/crates/vs-engine-webkit/src/backend/wpe_input.rs
+++ b/crates/vs-engine-webkit/src/backend/wpe_input.rs
@@ -185,12 +185,7 @@ impl InputDispatcher for XtestDispatcher {
     }
     fn dispatch(&self, ev: InputEvent) -> EngineResult<()> {
         let (type_, detail, root_x, root_y) = match ev {
-            InputEvent::Move(p) => (
-                XT_MOTION_NOTIFY,
-                0_u8,
-                clamp_i16(p.x),
-                clamp_i16(p.y),
-            ),
+            InputEvent::Move(p) => (XT_MOTION_NOTIFY, 0_u8, clamp_i16(p.x), clamp_i16(p.y)),
             InputEvent::Press(b) => (XT_BUTTON_PRESS, button_code(b), 0, 0),
             InputEvent::Release(b) => (XT_BUTTON_RELEASE, button_code(b), 0, 0),
         };
@@ -261,8 +256,16 @@ struct LibeiDispatcher {
 }
 
 enum LibeiCmd {
-    Motion { x: f64, y: f64, ack: mpsc::Sender<EngineResult<()>> },
-    Button { code: u32, pressed: bool, ack: mpsc::Sender<EngineResult<()>> },
+    Motion {
+        x: f64,
+        y: f64,
+        ack: mpsc::Sender<EngineResult<()>>,
+    },
+    Button {
+        code: u32,
+        pressed: bool,
+        ack: mpsc::Sender<EngineResult<()>>,
+    },
 }
 
 impl LibeiDispatcher {
@@ -280,19 +283,15 @@ impl LibeiDispatcher {
                     return;
                 };
                 rt.block_on(async move {
-                    let proxy = match RemoteDesktop::new().await {
-                        Ok(p) => p,
-                        Err(_) => {
-                            let _ = init_tx.send(None);
-                            return;
-                        }
+                    let Ok(proxy) = RemoteDesktop::new().await else {
+                        let _ = init_tx.send(None);
+                        return;
                     };
-                    let session: Session<'_, RemoteDesktop> = match proxy.create_session().await {
-                        Ok(s) => s,
-                        Err(_) => {
-                            let _ = init_tx.send(None);
-                            return;
-                        }
+                    let Ok(session): Result<Session<'_, RemoteDesktop>, _> =
+                        proxy.create_session().await
+                    else {
+                        let _ = init_tx.send(None);
+                        return;
                     };
                     let types: BitFlags<DeviceType> = DeviceType::Pointer.into();
                     if proxy

--- a/crates/vs-humanize/README.md
+++ b/crates/vs-humanize/README.md
@@ -111,7 +111,7 @@ Modern anti-bot systems (Cloudflare, hCaptcha, reCAPTCHA, DataDome) gate first o
 
 On macOS, `vs act click` and the coordinate primitives (`vs click-at`, `vs hover-at`, `vs move-to`, `vs drag`) route through native `NSEvent` mouseDown / mouseUp / mouseMoved on `WKWebView`. Each event carries `isTrusted = true` in JS, same as a real cursor click. The Bezier-pathed lead-in dispatched before every click reproduces Fitts-law arrival timing (digraph-derived control points, optional overshoot) so the visible motion looks like a human reaching the target rather than a teleport.
 
-Linux (WebKitGTK) and Windows (WebView2) currently still dispatch clicks through injected JS, so `isTrusted` is `false` on those engines. The next release (v0.1.9) wires native input on both: GDK `gdk_display_put_event` for WebKitGTK, CDP `Input.dispatchMouseEvent` for WebView2.
+Since v0.1.11 the coordinate primitives are native on Linux and Windows too: XTest over `x11rb` on WebKitGTK (X11 / Xwayland; pure Wayland falls back to `ENGINE_UNSUPPORTED`), `SendMouseInput` on a WebView2 composition controller on Windows. All three engines emit `isTrusted = true` for cursor-primitive clicks. Ref-based `vs act click` is trusted on macOS only — on Linux and Windows it still dispatches through injected JS (`isTrusted = false`); use the coordinate primitives there for fingerprint-sensitive sites.
 
 The walker also honors ARIA `role="..."` (Radix UI, Headless UI, Reach UI, every custom-div-as-button pattern), plus a tabindex heuristic for focusable divs/spans without a role. Modern React UIs surface as actionable refs without coordinate workarounds.
 
@@ -179,7 +179,7 @@ Every primitive call writes one row to a SQLite audit log before it returns. `vs
 
 The daemon auto-spawns on first call. State, captures, and downloads live under `~/.vibesurfer/`. The transport is an AF_UNIX socket on Unix (`~/.vibesurfer/daemon.sock`) and a Windows named pipe on Windows; either way, the CLI handles the difference.
 
-20 primitives total, each documented in [docs/PRIMITIVES.md](docs/PRIMITIVES.md). The full wire format with every sigil and edge case is in [docs/PROTOCOL.md](docs/PROTOCOL.md). The per-platform per-primitive verification matrix is in [docs/REALITY_CHECK.md](docs/REALITY_CHECK.md).
+29 wire primitives total — the 19 core primitives are specified in [docs/PRIMITIVES.md](docs/PRIMITIVES.md); the later additions (`vs_inspect`, the four cursor primitives, prompt-input, and the pending queue) are documented in the bundled [SKILL.md](crates/vs-cli/SKILL.md) and the CHANGELOG. The full wire format with every sigil and edge case is in [docs/PROTOCOL.md](docs/PROTOCOL.md). The per-platform per-primitive verification matrix is in [docs/REALITY_CHECK.md](docs/REALITY_CHECK.md).
 
 ## Configuration
 

--- a/crates/vs-protocol/README.md
+++ b/crates/vs-protocol/README.md
@@ -111,7 +111,7 @@ Modern anti-bot systems (Cloudflare, hCaptcha, reCAPTCHA, DataDome) gate first o
 
 On macOS, `vs act click` and the coordinate primitives (`vs click-at`, `vs hover-at`, `vs move-to`, `vs drag`) route through native `NSEvent` mouseDown / mouseUp / mouseMoved on `WKWebView`. Each event carries `isTrusted = true` in JS, same as a real cursor click. The Bezier-pathed lead-in dispatched before every click reproduces Fitts-law arrival timing (digraph-derived control points, optional overshoot) so the visible motion looks like a human reaching the target rather than a teleport.
 
-Linux (WebKitGTK) and Windows (WebView2) currently still dispatch clicks through injected JS, so `isTrusted` is `false` on those engines. The next release (v0.1.9) wires native input on both: GDK `gdk_display_put_event` for WebKitGTK, CDP `Input.dispatchMouseEvent` for WebView2.
+Since v0.1.11 the coordinate primitives are native on Linux and Windows too: XTest over `x11rb` on WebKitGTK (X11 / Xwayland; pure Wayland falls back to `ENGINE_UNSUPPORTED`), `SendMouseInput` on a WebView2 composition controller on Windows. All three engines emit `isTrusted = true` for cursor-primitive clicks. Ref-based `vs act click` is trusted on macOS only — on Linux and Windows it still dispatches through injected JS (`isTrusted = false`); use the coordinate primitives there for fingerprint-sensitive sites.
 
 The walker also honors ARIA `role="..."` (Radix UI, Headless UI, Reach UI, every custom-div-as-button pattern), plus a tabindex heuristic for focusable divs/spans without a role. Modern React UIs surface as actionable refs without coordinate workarounds.
 
@@ -179,7 +179,7 @@ Every primitive call writes one row to a SQLite audit log before it returns. `vs
 
 The daemon auto-spawns on first call. State, captures, and downloads live under `~/.vibesurfer/`. The transport is an AF_UNIX socket on Unix (`~/.vibesurfer/daemon.sock`) and a Windows named pipe on Windows; either way, the CLI handles the difference.
 
-20 primitives total, each documented in [docs/PRIMITIVES.md](docs/PRIMITIVES.md). The full wire format with every sigil and edge case is in [docs/PROTOCOL.md](docs/PROTOCOL.md). The per-platform per-primitive verification matrix is in [docs/REALITY_CHECK.md](docs/REALITY_CHECK.md).
+29 wire primitives total — the 19 core primitives are specified in [docs/PRIMITIVES.md](docs/PRIMITIVES.md); the later additions (`vs_inspect`, the four cursor primitives, prompt-input, and the pending queue) are documented in the bundled [SKILL.md](crates/vs-cli/SKILL.md) and the CHANGELOG. The full wire format with every sigil and edge case is in [docs/PROTOCOL.md](docs/PROTOCOL.md). The per-platform per-primitive verification matrix is in [docs/REALITY_CHECK.md](docs/REALITY_CHECK.md).
 
 ## Configuration
 

--- a/crates/vs-store/README.md
+++ b/crates/vs-store/README.md
@@ -111,7 +111,7 @@ Modern anti-bot systems (Cloudflare, hCaptcha, reCAPTCHA, DataDome) gate first o
 
 On macOS, `vs act click` and the coordinate primitives (`vs click-at`, `vs hover-at`, `vs move-to`, `vs drag`) route through native `NSEvent` mouseDown / mouseUp / mouseMoved on `WKWebView`. Each event carries `isTrusted = true` in JS, same as a real cursor click. The Bezier-pathed lead-in dispatched before every click reproduces Fitts-law arrival timing (digraph-derived control points, optional overshoot) so the visible motion looks like a human reaching the target rather than a teleport.
 
-Linux (WebKitGTK) and Windows (WebView2) currently still dispatch clicks through injected JS, so `isTrusted` is `false` on those engines. The next release (v0.1.9) wires native input on both: GDK `gdk_display_put_event` for WebKitGTK, CDP `Input.dispatchMouseEvent` for WebView2.
+Since v0.1.11 the coordinate primitives are native on Linux and Windows too: XTest over `x11rb` on WebKitGTK (X11 / Xwayland; pure Wayland falls back to `ENGINE_UNSUPPORTED`), `SendMouseInput` on a WebView2 composition controller on Windows. All three engines emit `isTrusted = true` for cursor-primitive clicks. Ref-based `vs act click` is trusted on macOS only — on Linux and Windows it still dispatches through injected JS (`isTrusted = false`); use the coordinate primitives there for fingerprint-sensitive sites.
 
 The walker also honors ARIA `role="..."` (Radix UI, Headless UI, Reach UI, every custom-div-as-button pattern), plus a tabindex heuristic for focusable divs/spans without a role. Modern React UIs surface as actionable refs without coordinate workarounds.
 
@@ -179,7 +179,7 @@ Every primitive call writes one row to a SQLite audit log before it returns. `vs
 
 The daemon auto-spawns on first call. State, captures, and downloads live under `~/.vibesurfer/`. The transport is an AF_UNIX socket on Unix (`~/.vibesurfer/daemon.sock`) and a Windows named pipe on Windows; either way, the CLI handles the difference.
 
-20 primitives total, each documented in [docs/PRIMITIVES.md](docs/PRIMITIVES.md). The full wire format with every sigil and edge case is in [docs/PROTOCOL.md](docs/PROTOCOL.md). The per-platform per-primitive verification matrix is in [docs/REALITY_CHECK.md](docs/REALITY_CHECK.md).
+29 wire primitives total — the 19 core primitives are specified in [docs/PRIMITIVES.md](docs/PRIMITIVES.md); the later additions (`vs_inspect`, the four cursor primitives, prompt-input, and the pending queue) are documented in the bundled [SKILL.md](crates/vs-cli/SKILL.md) and the CHANGELOG. The full wire format with every sigil and edge case is in [docs/PROTOCOL.md](docs/PROTOCOL.md). The per-platform per-primitive verification matrix is in [docs/REALITY_CHECK.md](docs/REALITY_CHECK.md).
 
 ## Configuration
 

--- a/crates/vs-store/src/auth.rs
+++ b/crates/vs-store/src/auth.rs
@@ -139,10 +139,27 @@ impl MasterKey {
         Ok(Self(buf))
     }
 
-    /// Persist the key as 32 raw bytes at `path`. Caller is responsible
-    /// for chmod-ing the file (typically 0600) and for ensuring the
-    /// destination directory exists.
+    /// Persist the key as 32 raw bytes at `path`. On Unix the file is
+    /// created with mode 0600 before the key bytes are written, so the
+    /// key is never observable by other users. Caller is responsible
+    /// for ensuring the destination directory exists.
     pub fn write_to_file(&self, path: impl AsRef<Path>) -> Result<()> {
+        #[cfg(unix)]
+        {
+            use std::io::Write as _;
+            use std::os::unix::fs::{OpenOptionsExt as _, PermissionsExt as _};
+            let mut f = fs::OpenOptions::new()
+                .write(true)
+                .create(true)
+                .truncate(true)
+                .mode(0o600)
+                .open(path.as_ref())?;
+            f.write_all(&self.0)?;
+            // `mode` only applies at creation; if the file pre-existed
+            // with looser permissions, tighten it now.
+            f.set_permissions(std::fs::Permissions::from_mode(0o600))?;
+        }
+        #[cfg(not(unix))]
         fs::write(path.as_ref(), self.0)?;
         Ok(())
     }
@@ -292,6 +309,32 @@ mod tests {
         k.write_to_file(&path).unwrap();
         let loaded = MasterKey::from_file(&path).unwrap();
         assert_eq!(k.0, loaded.0);
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn key_file_written_with_owner_only_permissions() {
+        use std::os::unix::fs::PermissionsExt as _;
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("key");
+        let k = MasterKey::generate().unwrap();
+        k.write_to_file(&path).unwrap();
+        let mode = std::fs::metadata(&path).unwrap().permissions().mode() & 0o777;
+        assert_eq!(mode, 0o600, "key file must be owner-only, got {mode:o}");
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn key_file_permissions_tightened_on_overwrite() {
+        use std::os::unix::fs::PermissionsExt as _;
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("key");
+        // Pre-existing world-readable file at the key path.
+        std::fs::write(&path, b"old").unwrap();
+        std::fs::set_permissions(&path, std::fs::Permissions::from_mode(0o644)).unwrap();
+        MasterKey::generate().unwrap().write_to_file(&path).unwrap();
+        let mode = std::fs::metadata(&path).unwrap().permissions().mode() & 0o777;
+        assert_eq!(mode, 0o600, "overwrite must tighten perms, got {mode:o}");
     }
 
     #[test]

--- a/dist/vibesurfer.rb
+++ b/dist/vibesurfer.rb
@@ -14,9 +14,9 @@
 class Vibesurfer < Formula
   desc "A browser for LLMs, not humans — agent-native headless WebKit + line-oriented protocol"
   homepage "https://github.com/frane/vibesurfer"
-  url "https://github.com/frane/vibesurfer/archive/refs/tags/v0.0.1.tar.gz"
+  url "https://github.com/frane/vibesurfer/archive/refs/tags/v0.1.13.tar.gz"
   # Update on each release: `shasum -a 256 <tarball>`.
-  sha256 "0000000000000000000000000000000000000000000000000000000000000000"
+  sha256 "7a2fe293af39508e88914673bcaf94b719d9037700da16eed5183cb21029d9cd"
   license "Apache-2.0"
   head "https://github.com/frane/vibesurfer.git", branch: "main"
 

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -73,14 +73,11 @@ docker run --rm --privileged -it \
 Useful for `cargo build` / single-test iteration. xvfb is set up via
 `xvfb-run` per command.
 
-## Windows (CI runner, manual verification)
+## Windows (CI runner)
 
-The WebView2 backend is currently `pending-manual-verification` —
-code + tests + CI workflow all exist, but the milestone-closing
-verification needs hands on a Windows machine. The CI workflow at
-`.github/workflows/m6-windows.yml` (lands in the next M6 transaction)
-runs the suite on `windows-latest`; the resulting artefact is the
-manual sign-off the maintainer applies after reviewing the run.
+The WebView2 backend implements every primitive and is verified in CI:
+the `windows` job in `.github/workflows/engine-tests.yml` runs the M6
+cell suite against real WebView2 on `windows-latest` on every push.
 
 `cargo test --test m6 -- --test-threads=1` is the same invocation;
 the Win32 message loop has the same single-threaded constraint as

--- a/docs/M6_PLAN.md
+++ b/docs/M6_PLAN.md
@@ -1,6 +1,11 @@
 # M6 plan — verification reality
 
-> Status: drafted 2026-05-07 at the start of M6. Updated as cells land.
+> **Status: completed (historical).** Drafted 2026-05-07 at the start
+> of M6. The goal below has been reached: every cell in
+> `docs/REALITY_CHECK.md` is `yes` on all three backends, and the M6
+> suite runs as load-bearing CI jobs on macOS, Linux, and Windows
+> (`.github/workflows/engine-tests.yml`). Kept as the record of how
+> M6 was sequenced.
 
 ## Goal
 

--- a/docs/PRIMITIVES.md
+++ b/docs/PRIMITIVES.md
@@ -1,8 +1,16 @@
 # Primitives
 
-The 19 primitives are the entire protocol surface. This document is the
-per-primitive specification — request shape, response shape, side
-effects, and audit row contents.
+This document is the per-primitive specification for the 19 **core**
+primitives (the M0–M5 protocol surface) — request shape, response
+shape, side effects, and audit row contents. Later releases added
+more wire primitives that are not yet specified here: `vs_inspect`
+(v0.1.8, eleven subcommands), the four cursor primitives `vs_move_to`
+/ `vs_click_at` / `vs_hover_at` / `vs_drag` (v0.1.8+),
+`vs_prompt_input` (v0.1.9), and the pending queue
+`vs_prompt_input_queue` / `vs_pending_*` (v0.1.12) — 29 wire
+primitives in total as of v0.1.13. Until they're specified here, the
+bundled [SKILL.md](../crates/vs-cli/SKILL.md) and the
+[CHANGELOG](../CHANGELOG.md) are their reference.
 
 For the wire envelope, framing, tree format, delta ops, and state-token
 mechanics, see [`PROTOCOL.md`](PROTOCOL.md). For role/error/warning code
@@ -160,10 +168,11 @@ counterpart to `vs_view`'s structural data.
 
 Persistent, encrypted auth state.
 
-- `save <name>`: dump cookies, localStorage, sessionStorage,
-  IndexedDB metadata; encrypt with AES-256-GCM via `ring` (key from
-  the OS keyring, falling back to `~/.vibesurfer/key`); insert into
-  `auth_blobs`.
+- `save <name>`: dump cookies (via the host-side cookie store, so
+  HttpOnly cookies are included), localStorage, and sessionStorage —
+  IndexedDB is **not** captured; encrypt with AES-256-GCM via `ring`
+  (key from the OS keyring, falling back to `~/.vibesurfer/key`);
+  insert into `auth_blobs`.
 - `load <name>`: reverse. Emits `? auth_loaded <name>` and forces a
   fresh `vs_view` baseline on next call.
 - `list`: enumerate stored blob names.

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -1,5 +1,13 @@
 # Roadmap
 
+> **Status: historical.** Milestones M0–M6 all shipped (v0.1.x). This
+> document is kept as the record of the original build order and exit
+> criteria; it is not a forward-looking plan. Post-M6 work is tracked
+> in the [CHANGELOG](../CHANGELOG.md) per release. Note the primitive
+> counts below describe the M5-era surface (19 primitives); v0.1.8+
+> added `vs_inspect`, the cursor primitives, prompt-input, and the
+> pending queue (29 wire primitives as of v0.1.13).
+
 Build order is sequential. Each milestone has explicit exit criteria.
 Stop at every milestone for review before starting the next.
 
@@ -147,8 +155,10 @@ do a real task within a 600-token bootstrap budget.
 
 ## Beyond M6 (not on the v1 critical path)
 
-- Windows engine support.
+- ~~Windows engine support.~~ *Shipped: the WebView2 backend implements
+  every primitive and the M6 suite runs on `windows-latest` in CI.*
+- ~~MCP shim (translates the protocol for Anthropic-style tool use).~~
+  *Shipped: `vs mcp`.*
 - Branching skill scripts (currently linear only).
-- MCP shim (translates the protocol for Anthropic-style tool use).
 - CDP shim (for Playwright/Puppeteer compatibility, if there's demand).
 - Network exposure of the daemon (with its own auth story).

--- a/docs/known-issues.md
+++ b/docs/known-issues.md
@@ -2,14 +2,14 @@
 
 Honest list of behaviors that aren't yet what they should be. Each entry has a short reproduction and a planned-or-tracked fix.
 
-## Wait conditions
-
-- **`NetIdle` is not implemented** on any backend. Calling it returns `! ENGINE_UNSUPPORTED webkit wait:net-idle-or-token-change` (or the equivalent on Linux/Windows). Implementing it requires DevTools-Protocol-style request tracking; not on the M5.5 critical path.
-- **`TokenChange` is not implemented**. Same response. Conceptually a daemon-level concern (waits on the page's state token to advance) rather than an engine concern; routing TBD.
-
 ## Act targets
 
 - **`ActTarget::Mark`** (act on a named anchor instead of a live ref) returns `NotImplemented` on every real backend. Marks already round-trip through `vs_mark` / `vs_annotate`; the missing piece is mapping a mark name to a current `data-vs-ref` attribute at act time. Land alongside the next round of mark-driven flows.
+
+## Trusted input coverage
+
+- Ref-based `vs act click` dispatches trusted native input on macOS only. On Linux (WebKitGTK) and Windows (WebView2) it still routes through injected JS (`isTrusted = false`); the coordinate cursor primitives (`vs click-at`, `vs hover-at`, `vs move-to`, `vs drag`) are the trusted path on those engines (since v0.1.11).
+- Pure-Wayland Linux without Xwayland returns `ENGINE_UNSUPPORTED` for the cursor primitives; the libei path landed in v0.1.12 but requires the compositor's RemoteDesktop portal consent.
 
 ## Layout on the stub
 
@@ -17,12 +17,7 @@ Honest list of behaviors that aren't yet what they should be. Each entry has a s
 
 ## Linux WPE viewport
 
-- `WpeBackend::set_viewport` resizes the WebView via GTK's `set_size_request` only. There's no equivalent of WKWebView's `setFrame` semantics on WebKitGTK; the resulting viewport may render at the requested CSS size but the page may not reflow as crisply on retina displays. Acceptable for layout extraction; less acceptable for pixel-perfect screenshots at non-default DPRs.
-
-## Windows WebView2
-
-- The Windows backend has `open` and `snapshot` implemented against `webview2-com`'s sample patterns, but **has not been verified at runtime** on a Windows host (we develop on macOS). CI on `windows-latest` will catch compile-level regressions; runtime correctness remains contingent on the COM message-loop integration with `MainThreadDispatcher`. Mark as "skeleton" in `vs status` until a Windows host actually drives a navigation end-to-end.
-- `act`, `wait`, `capture`, `layout`, `set_viewport` all return `NotImplemented` on Windows. Planned but not yet ported.
+- `WpeBackend::set_viewport` resizes the hidden host window and the WebView's size request. There's no equivalent of WKWebView's `setFrame` semantics on WebKitGTK; the resulting viewport may render at the requested CSS size but the page may not reflow as crisply on retina displays. Acceptable for layout extraction; less acceptable for pixel-perfect screenshots at non-default DPRs.
 
 ## DOM walker
 
@@ -30,7 +25,7 @@ Honest list of behaviors that aren't yet what they should be. Each entry has a s
 
 ## Auth blob portability
 
-- `vs_auth save` snapshots cookies + `localStorage` + `sessionStorage` only; it does **not** capture HttpOnly cookies (JS can't see them) or IndexedDB. For most agent flows that's enough. Native cookie-store extraction (WKHttpCookieStore on macOS, etc.) is a future enhancement.
+- `vs_auth save` snapshots cookies (via the host-side cookie store on all three backends, so HttpOnly cookies are included) plus `localStorage` + `sessionStorage`. It does **not** capture IndexedDB. For most agent flows that's enough.
 
 ## Daemon shutdown ordering
 

--- a/plugin/GEMINI.md
+++ b/plugin/GEMINI.md
@@ -60,9 +60,9 @@ Wire form is `vs_<name>` (over the socket); CLI subcommand is `<name>` with hyph
 | 12 | `vs annotate <TARGET> <KEY> [VALUE]` | `ref:N` / `mark:NAME` / `page` annotation. |
 | 17 | `vs viewport <PAGE> <SPEC> [--dpr=N]` | Preset (`mobile` / `desktop` / etc.) or `WxH`. Re-baselines next view. |
 
-### Cursor coordinates (20–23, v0.1.8+)
+### Cursor coordinates (20–23, v0.1.8+; trusted on all platforms in v0.1.11+)
 
-Coordinate-addressed input. Native trusted dispatch on macOS so events carry `isTrusted = true`; Linux + Windows currently return `ENGINE_UNSUPPORTED` until M7 wires GDK + CDP input. All four take `--mode={human,careful,robotic}` (short `-M`), default `human`.
+Coordinate-addressed input with native trusted dispatch on every backend. macOS uses `NSEvent`, Linux uses XTest via the pure-Rust `x11rb` client (or libei via xdg-desktop-portal RemoteDesktop on pure Wayland), Windows uses `SendMouseInput` on `ICoreWebView2CompositionController`. Every resulting `MouseEvent` carries `isTrusted = true` in JS — Cloudflare / Google / hCaptcha can't tell the click from a real cursor. All four primitives take `--mode={human,careful,robotic}` (short `-M`), default `human`.
 
 `human` synthesizes a Bezier path from the last known cursor position with Fitts-law arrival timing; the visible motion is indistinguishable from a real cursor reaching the target before the click. `careful` is a single-shot move. `robotic` is a teleport (no path).
 
@@ -71,10 +71,10 @@ Coordinate-addressed input. Native trusted dispatch on macOS so events carry `is
 | 20 | `vs move-to <PAGE> <X> <Y> [-M=human]` | `mt` | Move the cursor to (x, y). No click. |
 | 21 | `vs click-at <PAGE> <X> <Y> --token=<TOK> [-M=human]` | `ca` | Trusted click at (x, y) after a humanized lead-in. |
 | 22 | `vs hover-at <PAGE> <X> <Y> [-M=human]` | `ha` | Hover at (x, y). |
-| 23 | `vs drag <PAGE> <X1> <Y1> <X2> <Y2> --token=<TOK> [-M=human]` | `dr` | Press at start, drag along a humanized path, release at end. |
+| 23 | `vs drag <PAGE> <X1> <Y1> <X2> <Y2> --token=<TOK> [-M=human]` | `dr` | Press at start, drag along a humanized path, release at end. v0.1.11+ also synthesizes the HTML5 `DragEvent` chain (`dragstart` → `dragenter` → `dragover` → `drop` → `dragend` with a real `DataTransfer`) so react-dnd, native `draggable="true"` widgets, and React-Flow HTML5-backend nodes observe the drop. |
 
 
-### Human-in-loop (24–25, v0.1.9+)
+### Human-in-loop (24–25, v0.1.9+; MCP-aware in v0.1.12+)
 
 For credentials, TANs, and any other value the agent must not see. The CLI reads from the local terminal the user is sitting at; the agent never receives the bytes.
 
@@ -85,7 +85,7 @@ For credentials, TANs, and any other value the agent must not see. The CLI reads
 
 When you need credentials, never call `vs act fill` with the value. Always call `vs prompt-input <PAGE> <REF> --message="<label-from-snapshot>" --secret --token=<TOK>` and let the user type. Include enough context in the message that they know which field they're filling (the field label from the snapshot is usually enough).
 
-
+**MCP / Claude Desktop / Codex (v0.1.12+):** `vs mcp` has no tty, so the MCP version of `vs_prompt_input` enqueues a pending entry on the daemon and parks waiting for the value. The local user runs `vs pending list` (alias `pe ls`) to see what's queued and `vs pending fulfill [<id>]` (`pe f`) to type the value at their local tty — `vs pending fulfill` with no id auto-picks the single pending entry. `vs pending cancel <id>` (`pe c`) aborts. Once fulfilled, the agent's MCP tool call returns the new state token exactly as it would have for the local-CLI path.
 ### Search / extract (8, 10, 18)
 
 | # | CLI | What |
@@ -99,7 +99,7 @@ When you need credentials, never call `vs act fill` with the value. Always call 
 | # | CLI | What |
 |---|-----|------|
 | 15 | `vs skill list \| show <NAME>` | List or show installed skill bundles. |
-| 16 | `vs capture <PAGE> [<REF>] [--full-page]` | PNG to `~/.vibesurfer/captures/`. |
+| 16 | `vs capture <PAGE> [<REF>] [--full-page] [--base64]` | PNG to `~/.vibesurfer/captures/`. With `--base64` (`--b64`) the response body carries `base64=<bytes>` + `path=…` for MCP-driven agents that want the pixels inline (default ON over MCP). |
 | 19 | `vs auth save\|load\|list\|clear <PAGE> <NAME>` | Per-origin cookie+storage blob, AES-256-GCM at rest. |
 
 ## Optimistic concurrency
@@ -148,10 +148,10 @@ All three engines are verified in CI by the same 48-cell integration suite; the 
 | Backend | Renders | Trusted clicks | Viewport | Layout | Auth | Notes |
 |---------|---------|----------------|----------|--------|------|-------|
 | `webkit` (macOS) | ✅ | ✅ via `NSEvent` | ✅ | ✅ | ✅ | System WebKit.framework, `WKWebView`. |
-| `wpe` (Linux) | ✅ | JS `el.click()` (untrusted) | ✅ | ✅ | ✅ | WebKitGTK 6 via `webkit6` crate. Needs `libwebkitgtk-6.0`. |
-| `webview2` (Windows) | ✅ | JS `el.click()` (untrusted) | ✅ | ✅ | ✅ | Microsoft Edge / Chromium via `webview2-com`. |
+| `wpe` (Linux) | ✅ | ✅ via XTest (`x11rb`); libei (ashpd RemoteDesktop portal) on pure Wayland | ✅ | ✅ | ✅ | WebKitGTK 6 via `webkit6` crate. Needs `libwebkitgtk-6.0`. Pure Wayland without Xwayland and no portal → falls back to JS `el.click()` (untrusted). |
+| `webview2` (Windows) | ✅ | ✅ via `SendMouseInput` on `ICoreWebView2CompositionController` | ✅ | ✅ | ✅ | Microsoft Edge / Chromium via `webview2-com`. DirectComposition target per page. |
 
-Trusted clicks: only the macOS engine routes `vs act click` through native input dispatch so the resulting `MouseEvent` carries `isTrusted = true`. Linux + Windows still go through injected JS, which anti-bot fingerprinters (Cloudflare, Google, hCaptcha) will treat as automated. M7 wires both to their native equivalents (WebKitGTK GDK events and WebView2 CDP `Input.dispatchMouseEvent`).
+Trusted clicks (v0.1.11+): every backend routes `vs act click` and the cursor primitives through native OS input dispatch so the resulting `MouseEvent` carries `isTrusted = true` — anti-bot fingerprinters (Cloudflare, Google, hCaptcha) cannot distinguish from a real cursor. The Linux libei path requires the user's compositor to support the RemoteDesktop portal and the user to grant a one-time consent prompt at process startup; detection falls through to XTest (X11 / Xwayland) and finally to untrusted JS `el.click()` if neither is reachable.
 
 `vs status` reports the active backend's capabilities; the CLI surfaces the protocol error `ENGINE_UNSUPPORTED` if you try a primitive the active backend doesn't implement.
 


### PR DESCRIPTION
Fixes every finding from a full codebase quality review (~26k LoC, all six crates).

## Code fixes

- **CI gates**: `cargo fmt` drift in 8 files and three clippy 1.94 errors in the v0.1.12 libei path (`wpe_input.rs`) — both the fmt and ubuntu-clippy jobs were red on current stable.
- **Check-then-act race in `vs_act`**: a per-page mutation lock now covers the stale-token check → engine act → re-snapshot window, so two concurrent acts with the same `before_token` can no longer both pass the check. Lock lives outside the session-map mutex so slow engine calls don't block other pages. Regression test included.
- **File-permission hardening (Unix)**: fallback AES-256 master key written with mode 0600 (tightened on overwrite of a looser pre-existing file, with tests), `~/.vibesurfer` created/tightened to 0700, daemon socket chmod'd to 0600 after bind. Previously all three inherited the process umask — typically world-readable key, store, and socket.
- **Robustness**: `vs serve --stop` on Windows errors on an out-of-range PID instead of passing 0 to `OpenProcess`; snapshot nodes with refs beyond `u32` are dropped instead of aliasing `Ref(0)`; engine open/capture/eval completion paths return errors instead of `unreachable!()` panics.

## Release / docs truth sweep

- `dist/vibesurfer.rb`: v0.0.1 + zeroed SHA → v0.1.13 + real tarball SHA256.
- New `SECURITY.md` with a private disclosure path.
- `docs/known-issues.md`: removed shipped items (NetIdle/TokenChange waits, the Windows-skeleton section — the WebView2 backend implements every primitive and the M6 suite runs on `windows-latest` in CI); corrected the cookie-capture note (host-side store, HttpOnly included).
- README (+ all six crate mirrors via `scripts/sync-plugin.sh`): trusted-input section updated to the shipped v0.1.11 state, primitive count corrected to 29 wire primitives. The sync also caught a stale `plugin/GEMINI.md` that would have failed the CI mirror job.
- `docs/PRIMITIVES.md`: scoped to the 19 core primitives it specifies; dropped the false IndexedDB-capture claim for `vs_auth save`.
- `docs/ROADMAP.md` / `docs/M6_PLAN.md` marked historical; `docs/DEVELOPMENT.md` no longer calls Windows pending-manual-verification.
- CHANGELOG: Unreleased section covering all of the above.

## Verification

- `cargo fmt --check`, `cargo clippy --workspace --all-targets -- -D warnings`, and the full unit suite pass on Linux; daemon/store integration suites pass under xvfb.
- `e2e_cli` fails in the dev container identically on unmodified HEAD (environment artifact — real-engine test against example.com); CI runs it on macOS where it passes.
- macOS- and Windows-only paths touched here (eval/open completion handlers, `--stop` PID fix) are compile-verified only by the CI matrix — worth a look at the macOS/Windows jobs on this PR.

https://claude.ai/code/session_01QXRCDXZFHVMDZ7i6D1uoj8

---
_Generated by [Claude Code](https://claude.ai/code/session_01QXRCDXZFHVMDZ7i6D1uoj8)_