### PR TITLE
v0.1.14 release prep: changelog fold + version bumps

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ All notable changes to vibesurfer are recorded here. The format follows
 
 ## [Unreleased]
 
+
+
+## [v0.1.14] - 2026-06-11
+
 ### Security
 - File-permission hardening on Unix. The fallback AES-256 master key (`~/.vibesurfer/key`) is now created with mode 0600 (and tightened to 0600 when overwriting a pre-existing looser file); the daemon data directory (`~/.vibesurfer`) is created with / tightened to 0700; the daemon socket is chmod'd to 0600 after bind. Previously all three inherited the process umask, which typically left the key, the SQLite store (cookies + auth blobs), and the socket world-readable.
 - Added `SECURITY.md` with a private vulnerability-disclosure path.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2342,7 +2342,7 @@ checksum = "03c2856837ef78f57382f06b2b8563a2f512f7185d732608fd9176cb3b8edf0e"
 
 [[package]]
 name = "vibesurfer"
-version = "0.1.13"
+version = "0.1.14"
 dependencies = [
  "anyhow",
  "base64",
@@ -2370,7 +2370,7 @@ dependencies = [
 
 [[package]]
 name = "vs-daemon"
-version = "0.1.13"
+version = "0.1.14"
 dependencies = [
  "anyhow",
  "blake3",
@@ -2389,7 +2389,7 @@ dependencies = [
 
 [[package]]
 name = "vs-engine-webkit"
-version = "0.1.13"
+version = "0.1.14"
 dependencies = [
  "ashpd",
  "block2",
@@ -2414,11 +2414,11 @@ dependencies = [
 
 [[package]]
 name = "vs-humanize"
-version = "0.1.13"
+version = "0.1.14"
 
 [[package]]
 name = "vs-protocol"
-version = "0.1.13"
+version = "0.1.14"
 dependencies = [
  "proptest",
  "thiserror",
@@ -2426,7 +2426,7 @@ dependencies = [
 
 [[package]]
 name = "vs-store"
-version = "0.1.13"
+version = "0.1.14"
 dependencies = [
  "apple-native-keyring-store",
  "keyring-core",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.1.13"
+version = "0.1.14"
 edition = "2021"
 rust-version = "1.85"
 license = "Apache-2.0"

--- a/crates/vs-cli/Cargo.toml
+++ b/crates/vs-cli/Cargo.toml
@@ -21,10 +21,10 @@ name = "vs_cli"
 path = "src/lib.rs"
 
 [dependencies]
-vs-protocol = { path = "../vs-protocol", version = "0.1.13" }
-vs-daemon = { path = "../vs-daemon", version = "0.1.13" }
-vs-engine-webkit = { path = "../vs-engine-webkit", version = "0.1.13" }
-vs-store = { path = "../vs-store", version = "0.1.13" }
+vs-protocol = { path = "../vs-protocol", version = "0.1.14" }
+vs-daemon = { path = "../vs-daemon", version = "0.1.14" }
+vs-engine-webkit = { path = "../vs-engine-webkit", version = "0.1.14" }
+vs-store = { path = "../vs-store", version = "0.1.14" }
 clap = { version = "4", features = ["derive", "wrap_help"] }
 anyhow = "1"
 serde_json = "1"

--- a/crates/vs-cli/SKILL.md
+++ b/crates/vs-cli/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: vibesurfer
-version: 0.1.13
+version: 0.1.14
 binary: vs
 description: Agent-native headless browser. 20 primitives over a Unix-socket wire protocol. Real WKWebView (macOS), WebKitGTK 6 (Linux), or WebView2 (Windows) — all three engines CI-verified by 48 integration cells per platform. Optimistic concurrency via state tokens; tree-delta wire format; durable session/page/auth state in SQLite.
 ---

--- a/crates/vs-daemon/Cargo.toml
+++ b/crates/vs-daemon/Cargo.toml
@@ -16,9 +16,9 @@ workspace = true
 path = "src/lib.rs"
 
 [dependencies]
-vs-protocol = { path = "../vs-protocol", version = "0.1.13" }
-vs-store = { path = "../vs-store", version = "0.1.13" }
-vs-engine-webkit = { path = "../vs-engine-webkit", version = "0.1.13" }
+vs-protocol = { path = "../vs-protocol", version = "0.1.14" }
+vs-store = { path = "../vs-store", version = "0.1.14" }
+vs-engine-webkit = { path = "../vs-engine-webkit", version = "0.1.14" }
 tokio = { version = "1", features = ["rt-multi-thread", "net", "sync", "io-util", "macros", "signal", "time"] }
 blake3 = "1"
 thiserror = "2"
@@ -32,4 +32,4 @@ interprocess = { version = "2.4.2", features = ["tokio"] }
 [dev-dependencies]
 tempfile = "3"
 tokio = { version = "1", features = ["rt-multi-thread", "net", "sync", "io-util", "macros", "time", "test-util"] }
-vs-engine-webkit = { path = "../vs-engine-webkit", version = "0.1.13", features = ["test-support"] }
+vs-engine-webkit = { path = "../vs-engine-webkit", version = "0.1.14", features = ["test-support"] }

--- a/crates/vs-engine-webkit/Cargo.toml
+++ b/crates/vs-engine-webkit/Cargo.toml
@@ -21,8 +21,8 @@ workspace = true
 test-support = []
 
 [dependencies]
-vs-protocol = { path = "../vs-protocol", version = "0.1.13" }
-vs-humanize = { path = "../vs-humanize", version = "0.1.13" }
+vs-protocol = { path = "../vs-protocol", version = "0.1.14" }
+vs-humanize = { path = "../vs-humanize", version = "0.1.14" }
 thiserror = "2"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"

--- a/gemini-extension.json
+++ b/gemini-extension.json
@@ -1,6 +1,6 @@
 {
   "name": "vibesurfer",
-  "version": "0.1.13",
+  "version": "0.1.14",
   "contextFileName": "plugin/GEMINI.md",
   "mcpServers": {
     "vibesurfer": {

--- a/plugin/.claude-plugin/plugin.json
+++ b/plugin/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "vibesurfer",
   "description": "Agent-native headless browser.",
-  "version": "0.1.13",
+  "version": "0.1.14",
   "author": {
     "name": "Frane Bandov",
     "url": "https://github.com/frane"

--- a/plugin/.codex-plugin/plugin.json
+++ b/plugin/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "vibesurfer",
-  "version": "0.1.13",
+  "version": "0.1.14",
   "description": "Agent-native headless browser.",
   "author": {
     "name": "Frane Bandov",

--- a/plugin/GEMINI.md
+++ b/plugin/GEMINI.md
@@ -1,6 +1,6 @@
 ---
 name: vibesurfer
-version: 0.1.13
+version: 0.1.14
 binary: vs
 description: Agent-native headless browser. 20 primitives over a Unix-socket wire protocol. Real WKWebView (macOS), WebKitGTK 6 (Linux), or WebView2 (Windows) — all three engines CI-verified by 48 integration cells per platform. Optimistic concurrency via state tokens; tree-delta wire format; durable session/page/auth state in SQLite.
 ---

--- a/plugin/skills/vibesurfer/SKILL.md
+++ b/plugin/skills/vibesurfer/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: vibesurfer
-version: 0.1.13
+version: 0.1.14
 binary: vs
 description: Agent-native headless browser. 20 primitives over a Unix-socket wire protocol. Real WKWebView (macOS), WebKitGTK 6 (Linux), or WebView2 (Windows) — all three engines CI-verified by 48 integration cells per platform. Optimistic concurrency via state tokens; tree-delta wire format; durable session/page/auth state in SQLite.
 ---

--- a/skills/vibesurfer/SKILL.md
+++ b/skills/vibesurfer/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: vibesurfer
-version: 0.1.13
+version: 0.1.14
 binary: vs
 description: Agent-native headless browser. 20 primitives over a Unix-socket wire protocol. Real WKWebView (macOS), WebKitGTK 6 (Linux), or WebView2 (Windows) — all three engines CI-verified by 48 integration cells per platform. Optimistic concurrency via state tokens; tree-delta wire format; durable session/page/auth state in SQLite.
 ---


### PR DESCRIPTION
Release prep for v0.1.14:

- CHANGELOG: fold the `[Unreleased]` section (security hardening, act-race fix, robustness fixes, docs truth sweep from #1) into a `[v0.1.14] - 2026-06-11` entry.
- Bump workspace version and the nine inter-crate dependency pins to 0.1.14; regenerate `Cargo.lock`.
- Bump the version in `gemini-extension.json`, both plugin manifests, and the skill frontmatter (mirrors re-synced via `scripts/sync-plugin.sh`).

After this merges I'll tag `v0.1.14` (triggering the release workflow) and then update `dist/vibesurfer.rb` to the new tag's tarball SHA as a follow-up.

https://claude.ai/code/session_01QXRCDXZFHVMDZ7i6D1uoj8

---
_Generated by [Claude Code](https://claude.ai/code/session_01QXRCDXZFHVMDZ7i6D1uoj8)_