### PR TITLE
dist: point Homebrew formula at v0.1.14

### DIFF
--- a/dist/vibesurfer.rb
+++ b/dist/vibesurfer.rb
@@ -14,9 +14,9 @@
 class Vibesurfer < Formula
   desc "A browser for LLMs, not humans — agent-native headless WebKit + line-oriented protocol"
   homepage "https://github.com/frane/vibesurfer"
-  url "https://github.com/frane/vibesurfer/archive/refs/tags/v0.1.13.tar.gz"
+  url "https://github.com/frane/vibesurfer/archive/refs/tags/v0.1.14.tar.gz"
   # Update on each release: `shasum -a 256 <tarball>`.
-  sha256 "7a2fe293af39508e88914673bcaf94b719d9037700da16eed5183cb21029d9cd"
+  sha256 "d89e22c5796604a92c0f66e0429ee4e9262452e4d8b2cef7e87a4e6793c691c8"
   license "Apache-2.0"
   head "https://github.com/frane/vibesurfer.git", branch: "main"
 


### PR DESCRIPTION
Final v0.1.14 release chore: point the Homebrew formula at the published `v0.1.14` tag with the SHA256 computed from the actual release tarball (`d89e22c5…91c8`, verified by downloading and unpacking the archive).

The release itself is live: https://github.com/frane/vibesurfer/releases/tag/v0.1.14 (4 binaries + checksums.txt).

https://claude.ai/code/session_01QXRCDXZFHVMDZ7i6D1uoj8

---
_Generated by [Claude Code](https://claude.ai/code/session_01QXRCDXZFHVMDZ7i6D1uoj8)_