### PR TITLE
fix: secure fill no longer fails on a token captured before the human typed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to vibesurfer are recorded here. The format follows
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) and the project uses
 [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Fixed
+- Secure credential entry works against framework-driven login forms. `vs_prompt_form_wait` filled each value using the page token captured when `vs prompt-form` was called — before the human had even opened the entry URL. They then take seconds or minutes to type, and any re-render in that window (validation, focus, timers: constant on a React or Vue login) advances the token, so the fill failed the stale-token check and silently never ran. The pending entry was consumed, the form reported fulfilled, and the field stayed empty. The first field now reads the page's current token instead; later fields still chain off the preceding fill, which is the write they are genuinely sequenced after. A ref that no longer exists still fails loudly with `NOT_FOUND`. (Reported via `#vibesurfer`.)
+
 ## [0.2.2] - 2026-08-31
 
 ### Fixed

--- a/crates/vs-cli/SKILL.md
+++ b/crates/vs-cli/SKILL.md
@@ -100,6 +100,8 @@ But a credential YOU own is not a secret to protect from yourself: a test user y
 `vs prompt-scan <PAGE> [--open]` (alias `ps`) shows the human a live view of the headless page (a QR code, a 2FA screen) and blocks until they press Enter, so out-of-band steps like scanning a TOTP enrollment QR work. Over MCP, compose the existing tools instead: call `vs_watch` for the live URL, relay it, then `vs_prompt_confirm` to wait.
 
 **Browser entry (v0.1.23+):** the human alternative to the tty. `vs pending url` (`pe u`) mints a single-use loopback URL; the page lists every pending entry as one form (secret fields masked, password managers can autofill), and one submit fulfills them all. `vs prompt-form` prints such a URL automatically. Whole-login flow over MCP: call `vs_prompt_form` with all fields (`[{ref, label, secret}]`) — it returns `form` + `url` immediately; relay the URL to the user verbatim; then call `vs_prompt_form_wait` with the form id, which parks until submit and fills every ref in order. Values go browser → daemon → page; the agent never sees them. URLs are 127.0.0.1-only, 256-bit-nonce capability links, valid 10 minutes, consumed on submit.
+
+A password field masks to `***` in the tree whatever its value, so empty → filled moves the state token but filled → *different* value does not: the masked tree is byte-identical. That is not a stale view. To confirm a secret landed, check the field went from placeholder to `***`, or use `cap`. Nothing value-derived goes in the tree — a hash would be brute-forceable for a short secret and a length leaks the length.
 ### Search / extract (8, 10, 18)
 
 | # | CLI | What |

--- a/crates/vs-daemon/src/daemon/mod.rs
+++ b/crates/vs-daemon/src/daemon/mod.rs
@@ -814,10 +814,33 @@ impl Daemon {
         let mut token: Option<StateToken> = None;
         for (entry, value) in values {
             let before_token: StateToken = match token {
+                // Subsequent fields chain off the previous fill, which
+                // is the write this one is genuinely sequenced after.
                 Some(t) => t,
-                None => entry.token.parse().map_err(|_| {
-                    DaemonError::BadRequest("vs_prompt_form: bad token (not hex 16)".into())
-                })?,
+                // First field: read the page's *current* token rather
+                // than the one stored when `vs_prompt_form` was called.
+                //
+                // That stored token was captured before the human had
+                // even opened the entry URL. They then take seconds or
+                // minutes to type, and any re-render in that window —
+                // which a framework-driven login form does constantly,
+                // on validation, focus and timers — advances the token.
+                // The fill then failed the stale-token check and
+                // silently never ran: the pending entry was consumed,
+                // the daemon reported the form fulfilled, and the field
+                // stayed empty. Secure credential entry into a React or
+                // Vue login was impossible, which is the whole reason
+                // this primitive exists.
+                //
+                // The stale-token guard is there to stop an *agent*
+                // writing on the strength of a stale read. This is not
+                // that: the human authorised this exact value for this
+                // exact ref, and the delay is the feature. If the ref
+                // itself is gone the fill still fails loudly with
+                // NOT_FOUND, which is the honest error.
+                None => self
+                    .current_token(session_id, &entry.page)
+                    .unwrap_or(StateToken::ZERO),
             };
             let resp = self.act(ActCall {
                 session_id: session_id.to_string(),

--- a/crates/vs-daemon/tests/end_to_end.rs
+++ b/crates/vs-daemon/tests/end_to_end.rs
@@ -8,7 +8,7 @@ use std::time::Duration;
 
 use vs_daemon::{daemon::Daemon, page_state::ViewForm};
 use vs_engine_webkit::{self as engine, test_support::TestEngine, Engine, EngineRuntime};
-use vs_protocol::Ref;
+use vs_protocol::{Ref, StateToken};
 use vs_store::Store;
 
 fn make_daemon() -> (Daemon, tempfile::TempDir) {
@@ -1012,4 +1012,65 @@ fn download_list_reports_captured_intents() {
     assert_eq!(e.error, None);
     assert_eq!(e.mime, "application/pdf");
     assert!(e.url.starts_with("blob:"));
+}
+
+/// A secure form fill must survive the page changing while the human
+/// types.
+///
+/// `vs_prompt_form` captured the page token, then handed a URL to a
+/// person. They take seconds or minutes. Any re-render in that window
+/// — which a framework-driven login form does constantly, on
+/// validation, focus and timers — advances the token, and the fill
+/// then failed the stale-token check and silently never ran: pending
+/// entry consumed, form reported fulfilled, field still empty. Secure
+/// credential entry into a React or Vue login was impossible, which is
+/// what the primitive exists for.
+#[test]
+fn prompt_form_fill_survives_a_page_change_while_the_human_types() {
+    let (d, _dir) = make_daemon();
+    let s = d.session_open(Some("default")).unwrap();
+    let p = d.open(&s.session_id, "https://example.com/login").unwrap();
+    let before = d.view(&s.session_id, &p.page_id, false).unwrap();
+
+    // The agent asks for one secret, quoting the token it just read.
+    let (form_id, _url) = d
+        .prompt_form_enqueue(
+            &p.page_id,
+            vec![(Ref(3), "Password".to_string(), true)],
+            &before.token.to_string(),
+            None,
+        )
+        .expect("enqueue form");
+
+    // The page moves on while the human is typing. Navigating is the
+    // clearest stand-in available against the canned test tree — a
+    // re-baseline alone yields an identical token, because the token is
+    // derived from tree content and the fake engine's tree never
+    // changes. What matters is only that the page's current token no
+    // longer equals the one the form captured.
+    d.navigate(
+        &s.session_id,
+        &p.page_id,
+        "https://example.com/login?step=2",
+    )
+    .unwrap();
+    let after = d.view(&s.session_id, &p.page_id, true).unwrap();
+    assert_ne!(
+        before.token, after.token,
+        "test setup: the page must have moved for this to prove anything"
+    );
+
+    // The human submits.
+    let pending = d.pending_list();
+    let entry = pending
+        .iter()
+        .find(|e| e.form.as_deref() == Some(form_id.as_str()))
+        .expect("pending entry present");
+    assert!(d.pending_fulfill(&entry.id, "hunter2".into()));
+
+    // The fill must land, not fail on the token it captured minutes ago.
+    let token = d
+        .prompt_form_wait(&s.session_id, &form_id, Duration::from_secs(5))
+        .expect("secure fill must survive the page moving while a human types");
+    assert_ne!(token, StateToken::ZERO);
 }

--- a/plugin/skills/vibesurfer/SKILL.md
+++ b/plugin/skills/vibesurfer/SKILL.md
@@ -100,6 +100,8 @@ But a credential YOU own is not a secret to protect from yourself: a test user y
 `vs prompt-scan <PAGE> [--open]` (alias `ps`) shows the human a live view of the headless page (a QR code, a 2FA screen) and blocks until they press Enter, so out-of-band steps like scanning a TOTP enrollment QR work. Over MCP, compose the existing tools instead: call `vs_watch` for the live URL, relay it, then `vs_prompt_confirm` to wait.
 
 **Browser entry (v0.1.23+):** the human alternative to the tty. `vs pending url` (`pe u`) mints a single-use loopback URL; the page lists every pending entry as one form (secret fields masked, password managers can autofill), and one submit fulfills them all. `vs prompt-form` prints such a URL automatically. Whole-login flow over MCP: call `vs_prompt_form` with all fields (`[{ref, label, secret}]`) — it returns `form` + `url` immediately; relay the URL to the user verbatim; then call `vs_prompt_form_wait` with the form id, which parks until submit and fills every ref in order. Values go browser → daemon → page; the agent never sees them. URLs are 127.0.0.1-only, 256-bit-nonce capability links, valid 10 minutes, consumed on submit.
+
+A password field masks to `***` in the tree whatever its value, so empty → filled moves the state token but filled → *different* value does not: the masked tree is byte-identical. That is not a stale view. To confirm a secret landed, check the field went from placeholder to `***`, or use `cap`. Nothing value-derived goes in the tree — a hash would be brute-forceable for a short secret and a length leaks the length.
 ### Search / extract (8, 10, 18)
 
 | # | CLI | What |

--- a/skills/vibesurfer/SKILL.md
+++ b/skills/vibesurfer/SKILL.md
@@ -100,6 +100,8 @@ But a credential YOU own is not a secret to protect from yourself: a test user y
 `vs prompt-scan <PAGE> [--open]` (alias `ps`) shows the human a live view of the headless page (a QR code, a 2FA screen) and blocks until they press Enter, so out-of-band steps like scanning a TOTP enrollment QR work. Over MCP, compose the existing tools instead: call `vs_watch` for the live URL, relay it, then `vs_prompt_confirm` to wait.
 
 **Browser entry (v0.1.23+):** the human alternative to the tty. `vs pending url` (`pe u`) mints a single-use loopback URL; the page lists every pending entry as one form (secret fields masked, password managers can autofill), and one submit fulfills them all. `vs prompt-form` prints such a URL automatically. Whole-login flow over MCP: call `vs_prompt_form` with all fields (`[{ref, label, secret}]`) — it returns `form` + `url` immediately; relay the URL to the user verbatim; then call `vs_prompt_form_wait` with the form id, which parks until submit and fills every ref in order. Values go browser → daemon → page; the agent never sees them. URLs are 127.0.0.1-only, 256-bit-nonce capability links, valid 10 minutes, consumed on submit.
+
+A password field masks to `***` in the tree whatever its value, so empty → filled moves the state token but filled → *different* value does not: the masked tree is byte-identical. That is not a stale view. To confirm a secret landed, check the field went from placeholder to `***`, or use `cap`. Nothing value-derived goes in the tree — a hash would be brute-forceable for a short secret and a length leaks the length.
 ### Search / extract (8, 10, 18)
 
 | # | CLI | What |


### PR DESCRIPTION
Fixes the `#vibesurfer` report that `prompt-form` secure fill leaves React inputs empty.

## Cause

`vs_prompt_form_wait` filled using the page token captured when `vs prompt-form` ran — before the human had even opened the entry URL. They then take seconds or minutes to type, and any re-render in that window advances the token. A React or Vue login form re-renders constantly on validation, focus and timers, so the fill failed the stale-token check and never ran: pending entry consumed, form reported fulfilled, field still empty.

The delay is the whole point of this primitive, so keying the write to a token captured before the delay was self-defeating. It also explains why it looked like a React controlled-input problem — `act fill` already uses the prototype setter plus `input`/`change` and is fine, it just never got called — and why `vs type` appeared to work where fill did not.

## Fix

First field reads the page's current token. Later fields still chain off the preceding fill, which is the write they are genuinely sequenced after. The guard keeps doing its job everywhere it should: it exists to stop an *agent* writing on a stale read, and this is a human authorising one value for one ref. A ref that has since gone still fails loudly with `NOT_FOUND`.

## Verification

`prompt_form_fill_survives_a_page_change_while_the_human_types` navigates the page between enqueue and submit. Verified it fails with `StaleToken { reason: "mutate" }` when the fix alone is reverted, and passes with it.

Also closes the reporter's second issue, which was not a bug: a password field masks to `***` for any value, so replacing one non-empty secret with another yields a byte-identical tree and the token correctly does not move. Empty → filled does move it. Confirmed independently by another agent's live evidence. I am not putting value-derived material in the tree to make it move — a hash is brute-forceable for short secrets and a length leaks length.